### PR TITLE
feat: option for package local hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ the [Autoware][] project as an example.
 ```
 usage: ros2nix [-h]
                [--output OUTPUT | --output-as-ros-pkg-name | --output-as-nix-pkg-name]
-               [--output-dir OUTPUT_DIR] [--fetch] [--use-package-git-hash]
+               [--output-dir OUTPUT_DIR] [--fetch] [--use-per-package-src]
                [--patches | --no-patches] [--distro DISTRO]
                [--src-param SRC_PARAM] [--source-root SOURCE_ROOT]
                [--do-check] [--extra-build-inputs DEP1,DEP2,...]
@@ -149,13 +149,12 @@ options:
                         determined from the local git work tree. sourceRoot
                         attribute is set if needed and not overridden by
                         --source-root. (default: False)
-  --use-package-git-hash
-                        When using --fetch, use the git hash of the package
-                        sub-directory instead of the one of the upstream
-                        repo.This will lead to longer generation time and
-                        multiple source checkouts when building but will safe
-                        rebuilds of packages that have not changed. (default:
-                        False)
+  --use-per-package-src
+                        When using --fetch, fetch only the package sub-
+                        directory instead of the whole repo. For repos with
+                        multiple packages, this will avoid rebuilds of
+                        unchanged packages at the cost of longer generation
+                        time. (default: False)
   --patches, --no-patches
                         Add local git commits not present in git remote named
                         "origin" to patches in the generated Nix expression.

--- a/README.md
+++ b/README.md
@@ -113,10 +113,10 @@ the [Autoware][] project as an example.
 ```
 usage: ros2nix [-h]
                [--output OUTPUT | --output-as-ros-pkg-name | --output-as-nix-pkg-name]
-               [--output-dir OUTPUT_DIR] [--fetch] [--patches | --no-patches]
-               [--distro DISTRO] [--src-param SRC_PARAM]
-               [--source-root SOURCE_ROOT] [--do-check]
-               [--extra-build-inputs DEP1,DEP2,...]
+               [--output-dir OUTPUT_DIR] [--fetch] [--use-package-git-hash]
+               [--patches | --no-patches] [--distro DISTRO]
+               [--src-param SRC_PARAM] [--source-root SOURCE_ROOT]
+               [--do-check] [--extra-build-inputs DEP1,DEP2,...]
                [--extra-propagated-build-inputs DEP1,DEP2,...]
                [--extra-check-inputs DEP1,DEP2,...]
                [--extra-native-build-inputs DEP1,DEP2,...] [--flake]
@@ -149,6 +149,13 @@ options:
                         determined from the local git work tree. sourceRoot
                         attribute is set if needed and not overridden by
                         --source-root. (default: False)
+  --use-package-git-hash
+                        When using --fetch, use the git hash of the package
+                        sub-directory instead of the one of the upstream
+                        repo.This will lead to longer generation time and
+                        multiple source checkouts when building but will safe
+                        rebuilds of packages that have not changed. (default:
+                        False)
   --patches, --no-patches
                         Add local git commits not present in git remote named
                         "origin" to patches in the generated Nix expression.

--- a/ros2nix/ros2nix.py
+++ b/ros2nix/ros2nix.py
@@ -402,14 +402,11 @@ def ros2nix(args):
                     return subprocess.check_output(cmd, cwd=srcdir).decode().strip()
 
                 url = check_output("git config remote.origin.url".split())
-
                 prefix = check_output("git rev-parse --show-prefix".split())
-
                 toplevel = check_output("git rev-parse --show-toplevel".split())
-
                 head = check_output("git rev-parse HEAD".split())
 
-                def merge_base_to_upstream(commit: str)->str:
+                def merge_base_to_upstream(commit: str) -> str:
                     return subprocess.check_output(f"git merge-base {head} $(git for-each-ref refs/remotes/origin --format='%(objectname)')", cwd=srcdir,shell=True).decode().strip()
 
                 if args.use_package_git_hash:
@@ -417,7 +414,7 @@ def ros2nix(args):
                     merge_base = merge_base_to_upstream(head)
                     head = check_output(f"git rev-list {merge_base} -1 -- .".split())
 
-                if not args.use_package_git_hash and toplevel in git_cache: #only use cache if not using seperate checkout per package
+                if not args.use_package_git_hash and toplevel in git_cache: #only use cache if not using separate checkout per package
                     info = git_cache[toplevel]
                     upstream_rev = info["rev"]
                 else:
@@ -428,7 +425,13 @@ def ros2nix(args):
                     upstream_rev = merge_base_to_upstream(head)
                     info = json.loads(
                         subprocess.check_output(
-                            ["nix-prefetch-git", "--quiet"]+ (["--sparse-checkout", prefix] if (prefix and args.use_package_git_hash)  else [])+[ toplevel, upstream_rev],
+                            ["nix-prefetch-git", "--quiet"]
+                            + (
+                                ["--sparse-checkout", prefix]
+                                if prefix and args.use_package_git_hash
+                                else []
+                            )
+                            + [toplevel, upstream_rev],
                         ).decode()
                     )
                     git_cache[toplevel] = info
@@ -442,7 +445,7 @@ def ros2nix(args):
                         owner = "{match["owner"]}";
                         repo = "{match["repo"]}";
                         rev = "{info["rev"]}";
-                        sha256 = "{info["sha256"]}"; 
+                        sha256 = "{info["sha256"]}";
                         {sparse_checkout}
                       }}''').strip()
                 else:

--- a/ros2nix/ros2nix.py
+++ b/ros2nix/ros2nix.py
@@ -213,6 +213,9 @@ def comma_separated(arg: str) -> list[str]:
     return [i.strip() for i in arg.split(",")]
 
 
+def strip_empty_lines(text: str) -> str:
+    return os.linesep.join([s for s in text.splitlines() if s and not s.isspace()])
+
 def ros2nix(args):
     parser = argparse.ArgumentParser(
         prog="ros2nix", formatter_class=argparse.ArgumentDefaultsHelpFormatter
@@ -440,23 +443,23 @@ def ros2nix(args):
                 sparse_checkout = f"sparseCheckout = [\"{prefix}\"];" if (prefix and args.use_package_git_hash) else ""
                 if match is not None:
                     kwargs["src_param"] = "fetchFromGitHub"
-                    kwargs["src_expr"] = dedent(f'''
+                    kwargs["src_expr"] = strip_empty_lines(dedent(f'''
                       fetchFromGitHub {{
                         owner = "{match["owner"]}";
                         repo = "{match["repo"]}";
                         rev = "{info["rev"]}";
                         sha256 = "{info["sha256"]}";
                         {sparse_checkout}
-                      }}''').strip()
+                      }}''')).strip()
                 else:
                     kwargs["src_param"] = "fetchgit"
-                    kwargs["src_expr"] = dedent(f'''
+                    kwargs["src_expr"] = strip_empty_lines(dedent(f'''
                       fetchgit {{
                         url = "{url}";
                         rev = "{info["rev"]}";
                         sha256 = "{info["sha256"]}";
                         {sparse_checkout}
-                      }}''').strip()
+                      }}''')).strip()
 
                 if prefix:
                     # kwargs["src_expr"] = f'''let fullSrc = {kwargs["src_expr"]}; in "${{fullSrc}}/{prefix}"'''

--- a/ros2nix/ros2nix.py
+++ b/ros2nix/ros2nix.py
@@ -430,7 +430,7 @@ def ros2nix(args):
                         subprocess.check_output(
                             ["nix-prefetch-git", "--quiet"]
                             + (
-                                ["--sparse-checkout", prefix]
+                                ["--sparse-checkout", prefix, "--non-cone-mode"]
                                 if prefix and args.use_per_package_src
                                 else []
                             )
@@ -440,7 +440,9 @@ def ros2nix(args):
                     git_cache[toplevel] = info
 
                 match = re.match("https://github.com/(?P<owner>[^/]*)/(?P<repo>.*?)(.git|/.*)?$", url)
-                sparse_checkout = f"sparseCheckout = [\"{prefix}\"];" if (prefix and args.use_per_package_src) else ""
+                sparse_checkout = f"""sparseCheckout = ["{prefix}"];
+                        nonConeMode = true;""" if prefix and args.use_per_package_src else ""
+
                 if match is not None:
                     kwargs["src_param"] = "fetchFromGitHub"
                     kwargs["src_expr"] = strip_empty_lines(dedent(f'''

--- a/test/test.bats
+++ b/test/test.bats
@@ -113,3 +113,12 @@ load common.bash
     assert_file_not_contains ./ros-node.nix library-patch\.patch
     nix-build -A rosPackages.jazzy.ros-node
 }
+
+@test "--use-per-package-src" {
+    git clone https://github.com/wentasah/ros2nix
+    ros2nix --output-as-nix-pkg-name --fetch --use-per-package-src $(find "ros2nix/test/ws/src" -name package.xml)
+    nix-build -A rosPackages.jazzy.ros-node
+    run ./result/lib/ros_node/node
+    assert_success
+    assert_line --partial "hello world"
+}


### PR DESCRIPTION
closes https://github.com/wentasah/ros2nix/issues/17

Generally it works and I tested it also with patches. Patches that touch multiple packages might no longer be applicable though since the packages would then use different base versions.

Also the git cache is used much less frequently now (only if two packages have the same commit as last change) which leads to potentially largely increased generation time. Maybe it would be useful to replace the ``nix-prefetch-git`` with something more efficient, and deducting the hashes from one single checkout.