### PR TITLE
feat: add the option to store and load sha256 cache in/from a file

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,8 @@ usage: ros2nix [-h]
                [--output-dir OUTPUT_DIR] [--fetch] [--use-per-package-src]
                [--patches | --no-patches] [--distro DISTRO]
                [--src-param SRC_PARAM] [--source-root SOURCE_ROOT]
-               [--do-check] [--extra-build-inputs DEP1,DEP2,...]
+               [--cache-file CACHE_FILE] [--do-check]
+               [--extra-build-inputs DEP1,DEP2,...]
                [--extra-propagated-build-inputs DEP1,DEP2,...]
                [--extra-check-inputs DEP1,DEP2,...]
                [--extra-native-build-inputs DEP1,DEP2,...] [--flake]
@@ -172,6 +173,10 @@ options:
                         Set sourceRoot attribute value in the generated Nix
                         expression. Substring '{package_name}' gets replaced
                         with the package name. (default: None)
+  --cache-file CACHE_FILE
+                        Path to a json-file to store sha265 hashes of
+                        checkouts persistently to cache them across generation
+                        runs. (default: None)
   --do-check            Set doCheck attribute to true (default: False)
   --extra-build-inputs DEP1,DEP2,...
                         Additional dependencies to add to the generated Nix

--- a/README.md
+++ b/README.md
@@ -116,8 +116,7 @@ usage: ros2nix [-h]
                [--output-dir OUTPUT_DIR] [--fetch] [--use-per-package-src]
                [--patches | --no-patches] [--distro DISTRO]
                [--src-param SRC_PARAM] [--source-root SOURCE_ROOT]
-               [--cache-file CACHE_FILE] [--do-check]
-               [--extra-build-inputs DEP1,DEP2,...]
+               [--no-cache] [--do-check] [--extra-build-inputs DEP1,DEP2,...]
                [--extra-propagated-build-inputs DEP1,DEP2,...]
                [--extra-check-inputs DEP1,DEP2,...]
                [--extra-native-build-inputs DEP1,DEP2,...] [--flake]
@@ -173,10 +172,8 @@ options:
                         Set sourceRoot attribute value in the generated Nix
                         expression. Substring '{package_name}' gets replaced
                         with the package name. (default: None)
-  --cache-file CACHE_FILE
-                        Path to a json-file to store sha265 hashes of
-                        checkouts persistently to cache them across generation
-                        runs. (default: None)
+  --no-cache            Don't use cache of git checkout sha265 hashes across
+                        generation runs. (default: False)
   --do-check            Set doCheck attribute to true (default: False)
   --extra-build-inputs DEP1,DEP2,...
                         Additional dependencies to add to the generated Nix

--- a/ros2nix/ros2nix.py
+++ b/ros2nix/ros2nix.py
@@ -440,8 +440,9 @@ def ros2nix(args):
                                                    cwd=srcdir, shell=True).decode().strip()
 
                 if args.use_per_package_src:
-                    # we need to get merge_base again to filter out applied patches from the package git hash
-                    merge_base = merge_base_to_upstream(head)
+                    # Set head to point to the last commit the subdirectory was changed. This is
+                    # not strictly necessary, but it will increase hit rate of git_cache.
+                    merge_base = merge_base_to_upstream(head) # filter out locally applied patches
                     head = check_output(f"git rev-list {merge_base} -1 -- .".split())
 
                 def cache_key(url, prefix):

--- a/ros2nix/ros2nix.py
+++ b/ros2nix/ros2nix.py
@@ -598,6 +598,7 @@ def ros2nix(args):
         # TODO generate also release.nix (for testing/CI)?
 
     if not args.no_cache:
+        os.makedirs(os.path.dirname(cache_file), exist_ok=True)
         with open(cache_file, "w") as f:
             json.dump(git_cache, f)
 


### PR DESCRIPTION
cache is also used for per package source checkouts and <git-rev>-<package-prefix> is used as a key

Using a human-readable file format is not necessary for the cache but might be nice for introspection

Speeds up generation runs especially when ``--use-per-package-src`` is used
