### PR TITLE
Flags: external name and version arguments + name format + package only

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,14 +272,15 @@ kernel of your host system.
 usage: ros2nix [-h] [--output OUTPUT | --output-as-ros-pkg-name |
                --output-as-nix-pkg-name | --output-as-pkg-dir]
                [--output-dir OUTPUT_DIR] [--fetch [{nixpkgs,flake-inputs}]]
-               [--use-per-package-src] [--patches | --no-patches]
-               [--distro DISTRO] [--src-param SRC_PARAM]
-               [--source-root SOURCE_ROOT] [--no-cache] [--do-check]
-               [--extra-build-inputs DEP1,DEP2,...]
+               [--name-format NAME_FORMAT] [--name-param NAME_PARAM]
+               [--version-param VERSION_PARAM] [--use-per-package-src]
+               [--patches | --no-patches] [--distro DISTRO]
+               [--src-param SRC_PARAM] [--source-root SOURCE_ROOT]
+               [--no-cache] [--do-check] [--extra-build-inputs DEP1,DEP2,...]
                [--extra-propagated-build-inputs DEP1,DEP2,...]
                [--extra-check-inputs DEP1,DEP2,...]
-               [--extra-native-build-inputs DEP1,DEP2,...] [--flake]
-               [--default | --no-default] [--overlay | --no-overlay]
+               [--extra-native-build-inputs DEP1,DEP2,...] [--package-only]
+               [--flake] [--default | --no-default] [--overlay | --no-overlay]
                [--packages | --no-packages] [--shell | --no-shell]
                [--shell-only] [--nix-ros-overlay FLAKEREF] [--nixfmt]
                [--compare] [--copyright-holder COPYRIGHT_HOLDER]
@@ -323,6 +324,18 @@ options:
                         attribute of package derivations is set automatically
                         when required, unless it is explicitly overridden with
                         --source-root. (default: None)
+  --name-format NAME_FORMAT
+                        Format to use for the name in the resulting package
+                        expression. The string {distro} is replaced with the
+                        ros distro (set via --distro). Similarly,
+                        {package_name} is replaced with the name of the
+                        package. (default: ros-{distro}-{package_name})
+  --name-param NAME_PARAM
+                        Adds a parameter to the generated function and uses it
+                        as a value of the pname attribute (default: None)
+  --version-param VERSION_PARAM
+                        Adds a parameter to the generated function and uses it
+                        as a value of the version attribute (default: None)
   --use-per-package-src
                         When using --fetch, fetch only the package sub-
                         directory instead of the whole repo. For repos with
@@ -361,6 +374,8 @@ options:
   --extra-native-build-inputs DEP1,DEP2,...
                         Additional dependencies to add to the generated Nix
                         expressions (default: [])
+  --package-only        Generate only package.nix. This is a shortcut for
+                        --no-shell --no-default --no-overlay. (default: None)
   --flake               Generate top-level flake.nix instead of default.nix.
                         Use with --fetch if some package.xml files are outside
                         of the flake repo (default: False)

--- a/ros2nix/nix_expression.py
+++ b/ros2nix/nix_expression.py
@@ -177,48 +177,20 @@ class NixExpression:
         )
         ret += '{ ' + ', '.join(args) + ' }:'
 
-        if self.name_param:
-            name = self.name_param
-        else:
-            name = f'"{self.name_format.format(distro=self.distro_name, package_name=self.name)}"'
-
-        if self.version_param:
-            version = self.version_param
-        else:
-            version = f'"{self.version}"'
-
         # To prevent issues with infinite recursion, use inherit if the name
         # matches the passed param
-        if name == "pname":
-            name_arg = f"inherit pname"
-        else:
-            name_arg = f"pname = {name}"
+        def assign_attr(name, val):
+            return f"{name} = {val}" if name != val else f"inherit {name}"
 
-        if version == "version":
-            version_arg = f"inherit version"
-        else:
-            version_arg = f"version = {version}"
-
-        if src == "src":
-            src_arg = f"inherit src"
-        else:
-            src_arg = f"src = {src}"
-
-        ret += dedent('''
+        ret += dedent(f'''
         buildRosPackage rec {{
-          {name_arg};
-          {version_arg};
+          {assign_attr("pname", self.name_param or f'"{self.name_format.format(distro=self.distro_name, package_name=self.name)}"')};
+          {assign_attr("version", self.version_param or f'"{self.version}"')};
 
-          {src_arg};
+          {assign_attr("src", src)};
 
-          buildType = "{build_type}";
-        ''').format(
-            distro_name=self.distro_name,
-            name_arg=name_arg,
-            version_arg=version_arg,
-            src_arg=src_arg,
-            build_type=self.build_type,
-        )
+          buildType = "{self.build_type}";
+        ''')
         if self.patches:
             ret += f"""  patches = [\n    {"\n    ".join(self.patches)}\n  ];\n"""
 

--- a/ros2nix/nix_expression.py
+++ b/ros2nix/nix_expression.py
@@ -87,8 +87,11 @@ class NixExpression:
         description: str,
         licenses: Iterable[NixLicense],
         distro_name: str,
+        name_format: str,
         build_type: str,
         src_expr: str,
+        name_param: Optional[str] = None,
+        version_param: Optional[str] = None,
         build_inputs: Set[str] = set(),
         propagated_build_inputs: Set[str] = set(),
         check_inputs: Set[str] = set(),
@@ -107,9 +110,13 @@ class NixExpression:
         self.source_root = source_root
         self.do_check = do_check
 
+        self.name_param = name_param
+        self.version_param = version_param
+
         self.description = description
         self.licenses = licenses
         self.distro_name = distro_name
+        self.name_format = name_format
         self.build_type = build_type
 
         self.build_inputs = build_inputs
@@ -143,8 +150,15 @@ class NixExpression:
 
         args = ["lib", "buildRosPackage"]
 
+        if self.name_param:
+            args.append(self.name_param)
+
+        if self.version_param:
+            args.append(self.version_param)
+
         if self.src_param:
             args.append(self.src_param)
+
         src = indent(self.src_expr, "  ").strip()
 
         args.extend(
@@ -163,19 +177,49 @@ class NixExpression:
         )
         ret += '{ ' + ', '.join(args) + ' }:'
 
+        if self.name_param:
+            name = self.name_param
+        else:
+            name = f'"{self.name_format.format(
+                distro=self.distro_name,
+                package_name=self.name
+            )}"'
+
+        if self.version_param:
+            version = self.version_param
+        else:
+            version = f'"{self.version}"'
+
+        # To prevent issues with infinite recursion, use inherit if the name
+        # matches the passed param
+        if name == "pname":
+            name_arg = f"inherit pname"
+        else:
+            name_arg = f"pname = {name}"
+
+        if version == "version":
+            version_arg = f"inherit version"
+        else:
+            version_arg = f"version = {version}"
+
+        if src == "src":
+            src_arg = f"inherit src"
+        else:
+            src_arg = f"src = {src}"
+
         ret += dedent('''
         buildRosPackage rec {{
-          pname = "ros-{distro_name}-{name}";
-          version = "{version}";
+          {name_arg};
+          {version_arg};
 
-          src = {src};
+          {src_arg};
 
           buildType = "{build_type}";
         ''').format(
             distro_name=self.distro_name,
-            name=self.name,
-            version=self.version,
-            src=src,
+            name_arg=name_arg,
+            version_arg=version_arg,
+            src_arg=src_arg,
             build_type=self.build_type,
         )
         if self.patches:

--- a/ros2nix/nix_expression.py
+++ b/ros2nix/nix_expression.py
@@ -180,10 +180,7 @@ class NixExpression:
         if self.name_param:
             name = self.name_param
         else:
-            name = f'"{self.name_format.format(
-                distro=self.distro_name,
-                package_name=self.name
-            )}"'
+            name = f'"{self.name_format.format(distro=self.distro_name, package_name=self.name)}"'
 
         if self.version_param:
             version = self.version_param

--- a/ros2nix/ros2nix.py
+++ b/ros2nix/ros2nix.py
@@ -348,6 +348,7 @@ class PackageOnlyAction(argparse.Action):
         namespace.overlay = False
         namespace.packages = True
 
+
 def ros2nix(args):
     parser = argparse.ArgumentParser(
         prog="ros2nix", formatter_class=argparse.ArgumentDefaultsHelpFormatter
@@ -406,7 +407,7 @@ def ros2nix(args):
         help="Format to use for the name in the resulting package expression. "
         "The string {distro} is replaced with the ros distro (set via --distro). "
         "Similarly, {package_name} is replaced with the name of the package.",
-        default="ros-{distro}-{package_name}"
+        default="ros-{distro}-{package_name}",
     )
 
     parser.add_argument(

--- a/ros2nix/ros2nix.py
+++ b/ros2nix/ros2nix.py
@@ -341,6 +341,13 @@ class ShellOnlyAction(argparse.Action):
         namespace.packages = False
 
 
+class PackageOnlyAction(argparse.Action):
+    def __call__(self, parser, namespace, values, option_string=None):
+        namespace.shell = False
+        namespace.default = False
+        namespace.overlay = False
+        namespace.packages = True
+
 def ros2nix(args):
     parser = argparse.ArgumentParser(
         prog="ros2nix", formatter_class=argparse.ArgumentDefaultsHelpFormatter
@@ -392,6 +399,24 @@ def ros2nix(args):
 
         In all cases, the sourceRoot attribute of package derivations is set automatically when
         required, unless it is explicitly overridden with --source-root.''',
+    )
+
+    parser.add_argument(
+        "--name-format",
+        help="Format to use for the name in the resulting package expression. "
+        "The string {distro} is replaced with the ros distro (set via --distro). "
+        "Similarly, {package_name} is replaced with the name of the package.",
+        default="ros-{distro}-{package_name}"
+    )
+
+    parser.add_argument(
+        "--name-param",
+        help="Adds a parameter to the generated function and uses it as a value of the pname attribute",
+    )
+
+    parser.add_argument(
+        "--version-param",
+        help="Adds a parameter to the generated function and uses it as a value of the version attribute",
     )
 
     parser.add_argument(
@@ -462,7 +487,12 @@ def ros2nix(args):
         default=[],
         help="Additional dependencies to add to the generated Nix expressions",
     )
-
+    parser.add_argument(
+        "--package-only",
+        nargs=0,
+        action=PackageOnlyAction,
+        help="Generate only package.nix. This is a shortcut for --no-shell --no-default --no-overlay.",
+    )
     parser.add_argument(
         "--flake",
         action="store_true",
@@ -756,6 +786,12 @@ def ros2nix(args):
             if args.do_check:
                 kwargs["do_check"] = True
 
+            if args.name_param:
+                kwargs["name_param"] = args.name_param
+
+            if args.version_param:
+                kwargs["version_param"] = args.version_param
+
             derivation = NixExpression(
                 name=NixPackage.normalize_name(pkg.name),
                 version=pkg.version,
@@ -763,6 +799,7 @@ def ros2nix(args):
                 licenses=map(NixLicense, pkg.licenses),
                 distro_name=args.distro,
                 build_type=pkg.get_build_type(),
+                name_format=args.name_format,
                 build_inputs=build_inputs | set(args.extra_build_inputs),
                 propagated_build_inputs=propagated_build_inputs
                 | set(args.extra_propagated_build_inputs),

--- a/test/test.bats
+++ b/test/test.bats
@@ -61,6 +61,20 @@ fi
     assert [ -f out/shell.nix ]
 }
 
+@test "generate just package.nix with --package-only" {
+    cd ws
+    ros2nix --distro=jazzy --package-only $(find src -name package.xml)
+    assert [ $(find . -name '*.nix' -exec basename {} \; | uniq) = "package.nix" ]
+}
+
+@test "--package-only with --output-dir" {
+    cd ws
+    mkdir -p out
+    ros2nix --distro=jazzy --package-only $(find src -name package.xml) --output-dir=out --output-as-pkg-dir
+    assert [ -f out/ros-node/package.nix ]
+    assert [ -f out/library/package.nix ]
+}
+
 @test "nix-shell for local workspace with additional ROS package" {
     ros2nix --distro=jazzy $(find ws/src -name package.xml)
     nix-shell --arg withPackages 'p: with p; [ compressed-image-transport ]' \
@@ -317,4 +331,73 @@ EOF
     if $RUN_BUILD; then
         nix flake check --override-input ros2nix_test "$BATS_TEST_DIRNAME/.." path:"${PWD}"
     fi
+}
+
+@test "--src-param" {
+    cd ws/src/library
+
+    ros2nix --src-param testing-src $(find . -name package.xml)
+    assert [ -f package.nix ]
+
+    assert_file_contains package.nix "src = testing-src;"
+}
+
+@test "--src-param with inherit" {
+    cd ws/src/library
+
+    ros2nix --src-param src $(find . -name package.xml)
+    assert [ -f package.nix ]
+
+    assert_file_contains package.nix "inherit src;"
+}
+
+@test "--name-param" {
+    cd ws/src/library
+
+    ros2nix --name-param testing-name $(find . -name package.xml)
+    assert [ -f package.nix ]
+
+    assert_file_contains package.nix "name = testing-name;"
+}
+
+@test "--name-param with inherit" {
+    cd ws/src/library
+
+    ros2nix --name-param pname $(find . -name package.xml)
+    assert [ -f package.nix ]
+
+    assert_file_contains package.nix "inherit pname;"
+}
+
+@test "--version-param" {
+    cd ws/src/library
+
+    ros2nix --version-param testing-version $(find . -name package.xml)
+    assert [ -f package.nix ]
+
+    assert_file_contains package.nix "version = testing-version;"
+}
+
+@test "--version-param with inherit" {
+    cd ws/src/library
+
+    ros2nix --version-param version $(find . -name package.xml)
+    assert [ -f package.nix ]
+
+    assert_file_contains package.nix "inherit version;"
+}
+
+@test "--name-format" {
+    cd ws/src/library
+
+    ros2nix --distro=jazzy --name-format "non-conformant-name-{package_name}-{distro}" $(find . -name package.xml)
+    assert [ -f package.nix ]
+
+    assert_file_contains package.nix "name = \"non-conformant-name-library-jazzy\";"
+}
+
+@test "--name-format unknown substitution fail" {
+    cd ws/src/library
+
+    run ! ros2nix --distro=jazzy --name-format "{unknown_sub}-{package_name}-{distro}" $(find . -name package.xml)
 }

--- a/test/test.bats
+++ b/test/test.bats
@@ -64,7 +64,7 @@ fi
 @test "generate just package.nix with --package-only" {
     cd ws
     ros2nix --distro=jazzy --package-only $(find src -name package.xml)
-    assert [ $(find . -name '*.nix' -exec basename {} \; | uniq) = "package.nix" ]
+    assert [ "$(find . -name '*.nix' -exec basename {} \; | uniq)" = "package.nix" ]
 }
 
 @test "--package-only with --output-dir" {


### PR DESCRIPTION
I needed a bit more flexibility for a tool I'm working on, so I've added a pair of new flags that allow passing the name and the version as `callPackage` arguments. Additionally, there's a new flag for changing the package name's format and a new flag for creating only a `package.nix` file.

New flags:
`--name-param`: same as src-param but for name
`--version-param`: same as src-param but for version
`--package-only`: same idea as shell-only, but for package.nix 
`--name-format`: changes the format of the name generated for a package

Changes:
- When a `--x-param` flag matches the target attribute (e.g. `--src-param src`), use `inherit` instead to prevent infinite recursion.

I'm not quite sure what tests for these flags would look like, but if you want me to add them let me know.

P.S. Thank you for creating this and your work on `nix-ros-overlay`!