### PR TITLE
Pass explicit "-" when piping into nixfmt

### DIFF
--- a/ros2nix/ros2nix.py
+++ b/ros2nix/ros2nix.py
@@ -328,7 +328,9 @@ def strip_empty_lines(text: str) -> str:
 
 
 def nixfmt(input: str) -> str:
-    nixfmt = subprocess.Popen(["nixfmt"], stdin=subprocess.PIPE, stdout=subprocess.PIPE, text=True)
+    nixfmt = subprocess.Popen(
+        ["nixfmt", "-"], stdin=subprocess.PIPE, stdout=subprocess.PIPE, text=True
+    )
     output, _ = nixfmt.communicate(input=input)
     return output
 


### PR DESCRIPTION
nixfmt 1.3.0 deprecated reading stdin without a "-" argument, so the
bare invocation printed a warning on every generated expression:

  Warning: Bare invocation of nixfmt is deprecated. Use 'nixfmt -' for
  anonymous stdin.

Harmless today since stderr is not captured, but it will become an
error upstream, and communicate() would then silently return empty
output.
